### PR TITLE
Remove top-level await usage

### DIFF
--- a/src/lib/delegate_presets/index.ts
+++ b/src/lib/delegate_presets/index.ts
@@ -35,10 +35,3 @@ export async function getPreset(key: keyof typeof PRESETS) {
         return structuredClone<Record<string, DelegateAttrs>>(json);
     }
 }
-
-/**
- * @returns the default preset
- */
-export async function getDefaultPreset() {
-    return (await getPreset(defaultPresetKey()))!;
-}

--- a/src/lib/flags/flagcdn.ts
+++ b/src/lib/flags/flagcdn.ts
@@ -1,10 +1,19 @@
-const FLAG_CODES: Record<string, string> = 
-    await fetch("https://flagcdn.com/en/codes.json")
-    .then(r => r.json())
-    .catch(e => ({}));
+import { browser } from "$app/environment";
 
-export function getFlagUrl(key: string): URL | undefined {
-    if (key.toLowerCase() in FLAG_CODES) {
+let FLAG_CODES: Record<string, string> = {};
+async function _flag_codes(): Promise<typeof FLAG_CODES> {
+    if (Object.keys(FLAG_CODES).length > 0) return FLAG_CODES;
+
+    return FLAG_CODES = (
+        await fetch("https://flagcdn.com/en/codes.json")
+        .then(r => r.json())
+        .catch(e => {})
+    );
+}
+
+export async function getFlagUrl(key: string): Promise<URL | undefined> {
+    if (!browser) return;
+    if (key.toLowerCase() in await _flag_codes()) {
         return new URL(key.toLowerCase() + ".svg", "https://flagcdn.com/");
     }
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,10 +1,10 @@
-import { getDefaultPreset } from "$lib/delegate_presets";
+// We're assuming preset-un.json exists and is the default.
+import DEFAULT_DELEGATES from "$lib/delegate_presets/preset-un.json";
 import { DEFAULT_SORT_PRIORITY } from "$lib/motions/definitions";
 import type { AccessibleSettings, Settings } from "$lib/types";
 import { derived, readonly } from "svelte/store";
 import { createStore } from ".";
 
-const DEFAULT_DELEGATES = await getDefaultPreset();
 const { getDefaults, createContext, resetContext, getStoreContext } = createStore<Settings>("settings", 
     {
         delegateAttributes: DEFAULT_DELEGATES,

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -276,7 +276,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {#each Object.entries($delegateAttributes) as [key, attrs]}
+                    {#each Object.entries($delegateAttributes) as [key, attrs] (key)}
                     <tr>
                         <td>
                             <code>{key}</code>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -230,8 +230,8 @@
                                                     <Icon
                                                         icon="mdi:arrow-down"
                                                         class="{key.ascending ? 'rotate-180' : ''} transition-[transform]"
-                                                        width="1.2rem"
-                                                        height="1.2rem"
+                                                        width="1.2em"
+                                                        height="1.2em"
                                                     />
                                                 </button>
                                             </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,18 +2,5 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	// Allow any usage of new JS features:
-	build: {
-		target: "esnext"
-	},
-	esbuild: {
-		target: "esnext"
-	},
-	optimizeDeps:{
-		esbuildOptions: {
-			target: "esnext",
-		}
-	},
-	
 	plugins: [sveltekit()]
 });


### PR DESCRIPTION
Removes top-level await usage for flag loading and preset settings. This consequently,
- pushes flag image loading to client side
- fixes #14