### PR TITLE
Miscellaneous UI adjustments (incl. mobile support)

### DIFF
--- a/src/lib/components/IconLabel.svelte
+++ b/src/lib/components/IconLabel.svelte
@@ -1,0 +1,26 @@
+<!--
+    @component
+    
+    A piece of text that can be replaced with an icon on smaller screens.
+-->
+
+<script lang="ts">
+    import Icon from "@iconify/svelte";
+
+    interface Props {
+        icon: string,
+        label: string,
+        size?: string,
+        iconWidth?: number,
+        iconHeight?: number
+    }
+
+    let { icon, label, size = "md", iconWidth = 24, iconHeight = 24 }: Props = $props();
+</script>
+
+<!-- If on a smaller device, use an icon -->
+<div class="flex justify-center items-center {size}:hidden" aria-label={label} title={label}>
+    <Icon {icon} width={iconWidth} height={iconHeight} />
+</div>
+<!-- If on a larger device, use the full text -->
+<span class="hidden {size}:block">{label}</span>

--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -227,14 +227,14 @@
             {@const selected = speaker.id === selectedSpeakerId}
             {@const shadow = isDndShadow(speaker)}
             <li
-                class="!grid grid-cols-subgrid col-span-4 self-start dnd-list-item"
+                class="!grid grid-cols-subgrid col-span-4 dnd-list-item"
                 class:!visible={shadow}
                 class:!bg-surface-300-600-token={shadow}
                 use:bindToMap={[liElements, speaker.id]}
                 animate:flip={{ duration: 150 }}
                 aria-label={speakerLabel}
             >
-                <div class="btn-icon" use:dragHandle>
+                <div class="btn-icon w-6" use:dragHandle>
                     <Icon icon="mdi:drag-vertical" width="24" height="24" />
                 </div>
                 <span class="enumerated-index">{i + 1}.</span>

--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -158,6 +158,7 @@
             (async () => {
                 let selectedSpeaker = findSpeaker(selectedSpeakerId);
                 await onBeforeSpeakerUpdate?.(selectedSpeaker, speaker);
+                await tick();
                 selectedSpeakerId = speaker?.id;
             })()
         }

--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -228,7 +228,8 @@
             {@const shadow = isDndShadow(speaker)}
             <li
                 class="!grid grid-cols-subgrid col-span-4 self-start dnd-list-item"
-                class:shadow
+                class:!visible={shadow}
+                class:!bg-surface-300-600-token={shadow}
                 use:bindToMap={[liElements, speaker.id]}
                 animate:flip={{ duration: 150 }}
                 aria-label={speakerLabel}
@@ -327,15 +328,6 @@
 </div>
 
 <style lang="postcss">
-    /* Styling for shadow element */
-    .shadow {
-        @apply !visible;
-        @apply !bg-surface-300;
-    }
-    :global(.dark) .shadow {
-        @apply !bg-surface-600;
-    }
-
     /* Styling for dragged element */
     :global(#dnd-action-dragged-el).dnd-list-item {
         @apply !bg-surface-50;

--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -6,14 +6,17 @@
     
     import { type z } from "zod";
     import Icon from "@iconify/svelte";
-    import { popup } from "@skeletonlabs/skeleton";
+    import { getModalStore, popup } from "@skeletonlabs/skeleton";
     import { tick, untrack } from "svelte";
     import { flip } from "svelte/animate";
     import { dragHandle, dragHandleZone } from "svelte-dnd-action";
     import { getDndItemId, isDndShadow, processDrag } from "$lib/util/dnd";
+    import { triggerConfirmModal } from "$lib/util";
 
     let dfltControlsInput: string = $state("");
     let dfltControlsError: string | undefined = $state(undefined);
+
+    const modalStore = getModalStore();
 
     interface Props {
         /**
@@ -142,7 +145,12 @@
             setSelectedSpeaker(undefined);
         }
     }
-
+    function clearSpeakers() {
+        triggerConfirmModal(
+            modalStore, "Are you sure you want to clear the Speakers List?",
+            () => order = []
+        );
+    }
     /// Sets the selected speaker.
     function setSelectedSpeaker(speaker: Speaker | undefined) {
         if (selectedSpeakerId !== speaker?.id) {
@@ -193,11 +201,12 @@
     }
 </script>
 
-<div class="card p-2 overflow-y-auto flex-grow flex flex-col items-stretch gap-3">
+<div class="card p-4 overflow-y-hidden flex-grow flex flex-col items-stretch gap-4">
     <h4 class="h4 flex justify-center" id="speaker-list-header">
         Speakers List
     </h4>
-    <ol class="list grid grid-cols-[auto_auto_1fr_auto] auto-rows-min p-2 flex-grow" use:dragHandleZone={{
+
+    <ol class="p-2 list overflow-y-auto grid grid-cols-[auto_auto_1fr_auto] auto-rows-min flex-grow" use:dragHandleZone={{
         items: order,
         flipDurationMs: 150,
         dropTargetStyle: {},
@@ -256,10 +265,9 @@
             </li>
         {/each}
     </ol>
-</div>
 
-<!-- Default controls, consisting of a delegate input, an add button, and a clear button. -->
-{#if typeof useDefaultControls !== "undefined"}
+    <!-- Default controls, consisting of a delegate input, an add button, and a clear button. -->
+    {#if typeof useDefaultControls !== "undefined"}
     {@const popupID = useDefaultControls.popupID ?? "addDelegatePopup"}
     {@const error = typeof dfltControlsError !== "undefined"}
 
@@ -289,7 +297,7 @@
                 type="submit"
                 class="btn variant-filled-primary"
                 disabled={order.length === 0}
-                onclick={() => order = []}
+                onclick={clearSpeakers}
                 aria-label="Clear Speakers List"
                 title="Clear Speakers List"
             >
@@ -315,7 +323,8 @@
         presentDelegates={useDefaultControls.presentDelegates}
         on:selection={e => addSpeaker(e.detail.label, true)}
     />
-{/if}
+    {/if}
+</div>
 
 <style lang="postcss">
     /* Styling for shadow element */

--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -240,7 +240,7 @@
                 </div>
                 <span class="enumerated-index">{i + 1}.</span>
                 <button 
-                    class="btn overflow-clip"
+                    class="btn !text-wrap p-2 rounded-lg overflow-hidden"
                     class:variant-filled-primary={selected}
                     class:variant-soft-surface={!selected && speaker.completed}
                     class:variant-ringed-surface={!selected && !speaker.completed}

--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -274,7 +274,7 @@
     {@const error = typeof dfltControlsError !== "undefined"}
 
     <div class="flex flex-col gap-1">
-        <div class="flex flex-row gap-3">
+        <div class="flex flex-row gap-1">
             <!-- Add delegate -->
             <form class="contents" onsubmit={submitSpeaker} oninput={() => dfltControlsError = undefined}>
                 <input 
@@ -284,27 +284,31 @@
                     use:popup={{ ...defaultPopupSettings(popupID), placement: "left-end", event: "focus-click" }}
                     {...defaultPlaceholder(useDefaultControls.presentDelegates.length === 0)}
                 />
-                <button
-                    type="submit"
-                    class="btn variant-filled-primary"
-                    disabled={useDefaultControls.presentDelegates.length === 0}
-                    aria-label="Add to Speakers List"
-                    title="Add to Speakers List"
-                >
-                    Add
-                </button>
+                <div class="ml-2">
+                    <button
+                        type="submit"
+                        class="btn btn-icon variant-filled-primary"
+                        disabled={useDefaultControls.presentDelegates.length === 0}
+                        aria-label="Add to Speakers List"
+                        title="Add to Speakers List"
+                    >
+                        <Icon icon="mdi:plus" width="24" height="24" />
+                    </button>
+                </div>
+                <div>
+                    <!-- Clear order -->
+                    <button
+                        type="button"
+                        class="btn btn-icon variant-filled-primary"
+                        disabled={order.length === 0}
+                        onclick={clearSpeakers}
+                        aria-label="Clear Speakers List"
+                        title="Clear Speakers List"
+                    >
+                        <Icon icon="mdi:delete-outline" width="24" height="24" />
+                    </button>
+                </div>
             </form>
-            <!-- Clear order -->
-            <button
-                type="submit"
-                class="btn variant-filled-primary"
-                disabled={order.length === 0}
-                onclick={clearSpeakers}
-                aria-label="Clear Speakers List"
-                title="Clear Speakers List"
-            >
-                Clear
-            </button>
         </div>
         <!-- Error messages! -->
         <div class="text-error-500 text-center transition-[height] overflow-hidden {error ? 'h-6' : 'h-0'}">

--- a/src/lib/components/Timer.svelte
+++ b/src/lib/components/Timer.svelte
@@ -185,6 +185,7 @@
     >
         {#if editable && !running}
             {stringifyTime(secsRemaining())}/<span
+                class="border-b-4 border-transparent hover:border-surface-500 focus:border-surface-500 transition rounded"
                 contenteditable
                 onfocusout={setDuration}
                 onkeydown={titleKeyDown}

--- a/src/lib/components/app-bar/BarTitle.svelte
+++ b/src/lib/components/app-bar/BarTitle.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <h2 
-    class="h2 text-center break-all" 
+    class="h2 text-center break-all border-b-4 border-transparent hover:border-surface-500 focus:border-surface-500 transition rounded" 
     contenteditable 
     onfocusout={updateTitle} 
     onkeydown={keyDown} 

--- a/src/lib/components/del-label/DelLabel.svelte
+++ b/src/lib/components/del-label/DelLabel.svelte
@@ -29,6 +29,6 @@
 {:else}
 <div class="flex flex-col items-center gap-3">
     <h2 class="h2">{label}</h2>
-    <DelFlag {key} {attrs} height={height ?? "h-[25dvh]"} fallback={fallback ?? "un"} />
+    <DelFlag {key} {attrs} height={height ?? "h-48"} fallback={fallback ?? "un"} />
 </div>
 {/if}

--- a/src/lib/components/motions/ModCaucus.svelte
+++ b/src/lib/components/motions/ModCaucus.svelte
@@ -6,7 +6,7 @@
     import { getSessionDataContext } from "$lib/stores/session";
     import { getStatsContext, updateStats } from "$lib/stores/stats";
     import type { AppBarData, Motion, Speaker } from "$lib/types";
-    import { getContext, tick, untrack } from "svelte";
+    import { getContext, untrack } from "svelte";
 
     interface Props {
         motion: Motion & { kind: "mod" };
@@ -30,27 +30,20 @@
     let order: Speaker[] = $state([]);
     let selectedSpeaker = $derived(speakersList?.selectedSpeaker());
     $effect(() => {
-        selectedSpeaker;
-        reset();
-    });
-    $effect(() => {
         if (running) untrack(() => {
             speakersList?.start();
         })
     });
 
     // Button triggers
-    async function reset() {
+    function reset() {
         delTimer?.reset();
-        await tick();
     }
-    async function resetAll() {
+    function resetAll() {
         delTimer?.reset();
         totalTimer?.reset();
-        await tick();
     }
-    async function next() {
-        await reset();
+    function next() {
         speakersList?.next();
     }
 </script>

--- a/src/lib/components/motions/ModCaucus.svelte
+++ b/src/lib/components/motions/ModCaucus.svelte
@@ -6,6 +6,7 @@
     import { getSessionDataContext } from "$lib/stores/session";
     import { getStatsContext, updateStats } from "$lib/stores/stats";
     import type { AppBarData, Motion, Speaker } from "$lib/types";
+    import Icon from "@iconify/svelte";
     import { getContext, untrack } from "svelte";
 
     interface Props {
@@ -48,40 +49,53 @@
     }
 </script>
 
-<div class="grid grid-cols-[2fr_1fr] gap-12 h-full">
-    <!-- Left -->
-    <div class="flex flex-col gap-5 self-center">
-        {#if typeof selectedSpeaker !== "undefined"}
-            <DelLabel key={selectedSpeaker.key} attrs={$delegateAttributes[selectedSpeaker.key]} />
-        {/if}
-        <Timer 
-            name="delegate"
-            duration={motion.speakingTime}
-            bind:this={delTimer}
-            bind:running
-            disableKeyHandlers={typeof selectedSpeaker === "undefined"}
-            onPause={(t) => updateStats(stats, selectedSpeaker?.key, dat => dat.durationSpoken += t)}
-        />
-        <Timer
-            name="total"
-            duration={motion.totalTime}
-            bind:this={totalTimer}
-            bind:running
-            disableKeyHandlers
-        />
-        <div class="flex flex-row gap-3 justify-center">
-            {#if !running}
-                <button class="btn variant-filled-primary" disabled={typeof selectedSpeaker === "undefined"} onclick={() => running = true}>Start</button>
-            {:else}
-                <button class="btn variant-filled-primary" onclick={() => running = false}>Pause</button>
+<div class="flex flex-col lg:flex-row h-full gap-8 items-stretch">
+    <!--
+        Under mobile, the timer encompasses the whole page 
+        and the speakers list can be accessed by scrolling down.
+
+        Under desktop, both are on the same screen,
+        with the left side being the timer and the right side being the speakers list.
+    -->
+    <!-- Left/Top -->
+    <div class="flex flex-col flex-grow flex-shrink-0 basis-full lg:basis-auto">
+        <div class="flex flex-col gap-5 justify-center flex-grow">
+            {#if typeof selectedSpeaker !== "undefined"}
+                <DelLabel key={selectedSpeaker.key} attrs={$delegateAttributes[selectedSpeaker.key]} />
             {/if}
-            <button class="btn variant-filled-primary" disabled={speakersList?.isAllDone() ?? true} onclick={next}>Next</button>
-            <button class="btn variant-filled-primary" disabled={!delTimer?.canReset()} onclick={reset}>Reset</button>
-            <button class="btn variant-filled-primary" disabled={!totalTimer?.canReset()} onclick={resetAll}>Reset all</button>
+            <Timer 
+                name="delegate"
+                duration={motion.speakingTime}
+                bind:this={delTimer}
+                bind:running
+                disableKeyHandlers={typeof selectedSpeaker === "undefined"}
+                onPause={(t) => updateStats(stats, selectedSpeaker?.key, dat => dat.durationSpoken += t)}
+            />
+            <Timer
+                name="total"
+                duration={motion.totalTime}
+                bind:this={totalTimer}
+                bind:running
+                disableKeyHandlers
+            />
+            <div class="flex flex-row gap-3 justify-center">
+                {#if !running}
+                    <button class="btn variant-filled-primary" disabled={typeof selectedSpeaker === "undefined"} onclick={() => running = true}>Start</button>
+                {:else}
+                    <button class="btn variant-filled-primary" onclick={() => running = false}>Pause</button>
+                {/if}
+                <button class="btn variant-filled-primary" disabled={speakersList?.isAllDone() ?? true} onclick={next}>Next</button>
+                <button class="btn variant-filled-primary" disabled={!delTimer?.canReset()} onclick={reset}>Reset</button>
+                <button class="btn variant-filled-primary" disabled={!totalTimer?.canReset()} onclick={resetAll}>Reset all</button>
+            </div>
+        </div>
+        <!-- Mobile chevron -->
+        <div class="flex justify-center lg:hidden">
+            <Icon icon="mdi:chevron-down" width="24" height="24" />
         </div>
     </div>
-    <!-- Right -->
-    <div class="flex flex-col gap-6 h-full overflow-hidden">
+    <!-- Right/Bottom -->
+    <div class="flex flex-col gap-4 h-full lg:overflow-hidden lg:max-w-[33%]">
         <!-- List -->
         <SpeakerList
             bind:order

--- a/src/lib/components/motions/RoundRobin.svelte
+++ b/src/lib/components/motions/RoundRobin.svelte
@@ -5,7 +5,7 @@
     import { getSessionDataContext } from "$lib/stores/session";
     import { getStatsContext, updateStats } from "$lib/stores/stats";
     import type { AppBarData, Motion, Speaker } from "$lib/types";
-    import { getContext, tick, untrack } from "svelte";
+    import { getContext, untrack } from "svelte";
 
     interface Props {
         motion: Motion & { kind: "rr" };
@@ -28,22 +28,16 @@
     let order: Speaker[] = $state($presentDelegates.map(key => createSpeaker(key)));
     let selectedSpeaker = $derived(speakersList?.selectedSpeaker());
     $effect(() => {
-        selectedSpeaker;
-        reset();
-    });
-    $effect(() => {
         if (running) untrack(() => {
             speakersList?.start();
         })
     });
     
-    async function reset() {
+    function reset() {
         timer?.reset();
-        await tick();
     }
     // Button triggers
-    async function next() {
-        await reset();
+    function next() {
         speakersList?.next();
     }
 </script>

--- a/src/lib/components/motions/RoundRobin.svelte
+++ b/src/lib/components/motions/RoundRobin.svelte
@@ -5,6 +5,7 @@
     import { getSessionDataContext } from "$lib/stores/session";
     import { getStatsContext, updateStats } from "$lib/stores/stats";
     import type { AppBarData, Motion, Speaker } from "$lib/types";
+    import Icon from "@iconify/svelte";
     import { getContext, untrack } from "svelte";
 
     interface Props {
@@ -42,32 +43,45 @@
     }
 </script>
 
-<div class="grid grid-cols-[2fr_1fr] gap-12 h-full">
-    <!-- Left -->
-    <div class="flex flex-col gap-5 self-center">
-        {#if typeof selectedSpeaker !== "undefined"}
-            <DelLabel key={selectedSpeaker.key} attrs={$delegateAttributes[selectedSpeaker.key]} />
-        {/if}
-        <Timer 
-            name="total"
-            duration={motion.speakingTime} 
-            bind:this={timer}
-            bind:running 
-            disableKeyHandlers={typeof selectedSpeaker === "undefined"}
-            onPause={(t) => updateStats(stats, selectedSpeaker?.key, dat => dat.durationSpoken += t)}
-        />
-        <div class="flex flex-row gap-3 justify-center">
-            {#if !running}
-                <button class="btn variant-filled-primary" disabled={typeof selectedSpeaker === "undefined"} onclick={() => running = true}>Start</button>
-            {:else}
-                <button class="btn variant-filled-primary" onclick={() => running = false}>Pause</button>
+<div class="flex flex-col lg:flex-row h-full gap-8 items-stretch">
+    <!--
+        Under mobile, the timer encompasses the whole page 
+        and the speakers list can be accessed by scrolling down.
+
+        Under desktop, both are on the same screen,
+        with the left side being the timer and the right side being the speakers list.
+    -->
+    <!-- Left/Top -->
+    <div class="flex flex-col flex-grow flex-shrink-0 basis-full lg:basis-auto">
+        <div class="flex flex-col gap-5 justify-center flex-grow">
+            {#if typeof selectedSpeaker !== "undefined"}
+                <DelLabel key={selectedSpeaker.key} attrs={$delegateAttributes[selectedSpeaker.key]} />
             {/if}
-            <button class="btn variant-filled-primary" disabled={speakersList?.isAllDone() ?? true} onclick={next}>Next</button>
-            <button class="btn variant-filled-primary" disabled={!timer?.canReset()} onclick={reset}>Reset</button>
+            <Timer 
+                name="total"
+                duration={motion.speakingTime} 
+                bind:this={timer}
+                bind:running 
+                disableKeyHandlers={typeof selectedSpeaker === "undefined"}
+                onPause={(t) => updateStats(stats, selectedSpeaker?.key, dat => dat.durationSpoken += t)}
+            />
+            <div class="flex flex-row gap-3 justify-center">
+                {#if !running}
+                    <button class="btn variant-filled-primary" disabled={typeof selectedSpeaker === "undefined"} onclick={() => running = true}>Start</button>
+                {:else}
+                    <button class="btn variant-filled-primary" onclick={() => running = false}>Pause</button>
+                {/if}
+                <button class="btn variant-filled-primary" disabled={speakersList?.isAllDone() ?? true} onclick={next}>Next</button>
+                <button class="btn variant-filled-primary" disabled={!timer?.canReset()} onclick={reset}>Reset</button>
+            </div>
+        </div>
+        <!-- Mobile chevron -->
+        <div class="flex justify-center lg:hidden">
+            <Icon icon="mdi:chevron-down" width="24" height="24" />
         </div>
     </div>
-    <!-- Right -->
-    <div class="flex flex-col gap-6 h-full overflow-hidden">
+    <!-- Right/Bottom -->
+    <div class="flex flex-col gap-4 h-full lg:overflow-hidden lg:max-w-[33%]">
         <!-- List -->
         <SpeakerList
             bind:order

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -44,3 +44,9 @@
 {@render children()}
 
 <svelte:window onkeydown={keydown} onstorage={storage} />
+<div class="hidden">
+    <!-- Force these styling classes to always exist -->
+    <!-- see IconLabel.svelte -->
+    <div class="sm:hidden md:hidden lg:hidden xl:hidden 2xl:hidden"></div>
+    <div class="sm:block md:block lg:block xl:block 2xl:block"></div>
+</div>

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -86,10 +86,12 @@
                     <Icon icon="mdi:menu" width="24" height="24" />
                 </button>
             {/snippet}
-            <div class="flex flex-col gap-1">
-                <BarTitle bind:title={$title} />
-                <hr class="divider border-t-4 border-surface-800-100-token" />
-                <BarStats total={$presentDelegates.length} />
+            <div class="flex flex-col">
+                <div class="flex flex-col gap-1">
+                    <BarTitle bind:title={$title} />
+                    <hr class="divider border-t-4 mb-1 border-surface-800-100-token" />
+                    <BarStats total={$presentDelegates.length} />
+                </div>
                 {#if appBarData.topic}
                     <h3 class="h3 capitalize self-center mt-3"><i>Topic: {appBarData.topic}</i></h3>
                 {/if}

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import DelLabel from "$lib/components/del-label/DelLabel.svelte";
+  import IconLabel from "$lib/components/IconLabel.svelte";
   import MotionForm, { numSpeakersStr } from "$lib/components/MotionForm.svelte";
   import EditMotionCard from "$lib/components/modals/EditMotionCard.svelte";
   import { MOTION_LABELS } from "$lib/motions/definitions";
@@ -100,12 +101,12 @@
   );
 </script>
 
-<div class="grid gap-5 sm:grid-cols-[1fr_2fr] h-full">
+<div class="grid gap-5 min-h-full md:grid-cols-[1fr_2fr] md:h-full">
   <div class="card motion-form">
     <MotionForm submit={submitMotion} />
   </div>
   
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-2 overflow-x-auto">
     <div class="grid grid-cols-[1fr_auto] items-center">
       <h3 class="h3 text-center" id="motion-table-header">List of Motions</h3>
       <button
@@ -125,13 +126,13 @@
       <table class="table [&_td]:!align-middle [&_td]:!text-wrap" bind:this={motionTable}>
         <thead>
           <tr>
-            <td class="w-24"></td>
+            <td class="w-[7.5rem]"></td>
             <td class="px-3 w-24">Motion</td>
             <td class="px-3 w-32">By</td>
             <td class="px-3">Topic</td>
-            <td class="px-3 w-24">Total Time</td>
-            <td class="px-3 w-24">Speaking Time</td>
-            <td class="px-3 w-24">No. of Speakers</td>
+            <td class="px-3 w-16"><IconLabel icon="mdi:clock" label="Total Time" /></td>
+            <td class="px-3 w-16"><IconLabel icon="mdi:account-clock" label="Speaking Time" /></td>
+            <td class="px-3 w-16"><IconLabel icon="mdi:account-multiple" label="No. of Speakers" /></td>
           </tr>
         </thead>
         <tbody
@@ -158,7 +159,7 @@
               <td>
                 <div class="flex flex-row">
                   <button
-                    class="btn btn-sm btn-icon"
+                    class="btn btn-sm btn-icon w-8"
                     onclick={() => removeMotion(i)}
                     data-label="Reject {delName}'s Motion"
                     title="Reject {delName}'s Motion"
@@ -166,9 +167,10 @@
                     <Icon icon="mdi:cancel" width="24" height="24" class="text-error-500" />
                   </button>
                   <a
-                    class="btn btn-sm btn-icon"
+                    class="btn btn-sm btn-icon w-8"
                     onclick={() => acceptMotion(motion)}
                     href="{base}/dashboard/current-motion"
+                    role="button"
                     data-label="Accept {delName}'s Motion"
                     title="Accept {delName}'s Motion"
                     tabindex={0}
@@ -176,7 +178,7 @@
                     <Icon icon="mdi:check" width="24" height="24" class="text-success-700" />
                   </a>
                   <button
-                    class="btn btn-sm btn-icon"
+                    class="btn btn-sm btn-icon w-8"
                     onclick={() => editMotion(i, motion)}
                     data-label="Edit {delName}'s Motion"
                     title="Edit {delName}'s Motion"

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -122,7 +122,7 @@
     </div>
     
     <div class="table-container">
-      <table class="table motion-table" bind:this={motionTable}>
+      <table class="table [&_td]:!align-middle [&_td]:!text-wrap" bind:this={motionTable}>
         <thead>
           <tr>
             <td class="w-24"></td>
@@ -134,12 +134,13 @@
             <td class="px-3 w-24">No. of Speakers</td>
           </tr>
         </thead>
-        <tbody use:dndzone={{
-          items: $motions,
-          flipDurationMs: 150,
-          dropTargetStyle: {},
-          transformDraggedElement: (el) => createDragTr(el, motionTable)
-        }}
+        <tbody
+          use:dndzone={{
+            items: $motions,
+            flipDurationMs: 150,
+            dropTargetStyle: {},
+            transformDraggedElement: (el) => createDragTr(el, motionTable)
+          }}
           onconsider={(e) => motions.set(processDrag(e))}
           onfinalize={(e) => motions.set(processDrag(e))}
           aria-labelledby="motion-table-header"
@@ -148,8 +149,9 @@
             {@const delName = $delegateAttributes[motion.delegate]?.name ?? motion.delegate}
             {@const shadow = isDndShadow(motion)}
             <tr 
-              class="dnd-list-item"
-              class:shadow
+              class="dnd-list-item hover:!bg-primary-500/25"
+              class:!visible={shadow}
+              class:!bg-surface-300-600-token={shadow}
               animate:flip={{ duration: 150 }}
               aria-label="{delName}'s Motion"
             >
@@ -198,24 +200,6 @@
 </div>
 
 <style lang="postcss">
-  .motion-table td {
-    vertical-align: middle;
-  }
-
-  /* If we're NOT dragging an item, enable the hover effect. */
-  .motion-table tbody tr:hover:not(:active) {
-    @apply !bg-primary-500/25;
-  }
-
-  /* Styling for shadow element */
-  .shadow {
-      @apply !visible;
-      @apply !bg-surface-300;
-  }
-  :global(.dark) .shadow {
-      @apply !bg-surface-600;
-  }
-
   /* Styling for dragged element */
   :global(#dnd-action-dragged-el).dnd-list-item {
       @apply !opacity-90;

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -100,7 +100,7 @@
     <MotionForm submit={submitMotion} />
   </div>
   
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-2 overflow-y-auto">
     <div class="grid grid-cols-[1fr_auto] items-center">
       <h3 class="h3 text-center" id="motion-table-header">List of Motions</h3>
       <button

--- a/src/routes/dashboard/roll-call/+page.svelte
+++ b/src/routes/dashboard/roll-call/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import { base } from "$app/paths";
     import DelLabel from "$lib/components/del-label/DelLabel.svelte";
+    import IconLabel from "$lib/components/IconLabel.svelte";
     import { getSessionDataContext } from "$lib/stores/session";
     import type { DelegatePresence } from "$lib/types";
     import { mapObj } from "$lib/util";
-    import Icon from "@iconify/svelte";
     import { RadioGroup, RadioItem } from "@skeletonlabs/skeleton";
 
     const { settings: { delegateAttributes }, delegateAttendance } = getSessionDataContext();
@@ -31,12 +31,7 @@
                 <RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary" border="" background="bg-surface-300-600-token">
                     {#each Object.entries(radio) as [value, { label, icon }]}
                         <RadioItem bind:group={$delegateAttendance[key]} name="presence-{key}" {value}>
-                            <!-- If on a small device, use an icon -->
-                            <div class="flex justify-center items-center md:hidden" aria-label={label} title={label}>
-                                <Icon {icon} width="24" height="24" />
-                            </div>
-                            <!-- If on a larger device, use the full text -->
-                            <span class="hidden md:block">{label}</span>
+                            <IconLabel {icon} {label} />
                         </RadioItem>
                     {/each}
                 </RadioGroup>

--- a/src/routes/dashboard/roll-call/+page.svelte
+++ b/src/routes/dashboard/roll-call/+page.svelte
@@ -2,13 +2,21 @@
     import { base } from "$app/paths";
     import DelLabel from "$lib/components/del-label/DelLabel.svelte";
     import { getSessionDataContext } from "$lib/stores/session";
+    import type { DelegatePresence } from "$lib/types";
     import { mapObj } from "$lib/util";
+    import Icon from "@iconify/svelte";
     import { RadioGroup, RadioItem } from "@skeletonlabs/skeleton";
 
     const { settings: { delegateAttributes }, delegateAttendance } = getSessionDataContext();
     delegateAttributes.subscribe($da => {
         $delegateAttendance = mapObj($da, k => [k, $delegateAttendance[k] ?? "NP"]);
     });
+
+    const radio: Record<DelegatePresence, { label: string, icon: string }> = {
+        NP: { label: "Absent", icon: "mdi:account-off" },
+        P:  { label: "Present", icon: "mdi:account" },
+        PV: { label: "Present and Voting", icon: "mdi:account-check" },
+    };
 </script>
 
 <!-- Render a table to display participants and their statuses -->
@@ -21,9 +29,16 @@
             </div>
             <div class="flex flex-col justify-center p-2">
                 <RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary" border="" background="bg-surface-300-600-token">
-                    <RadioItem bind:group={$delegateAttendance[key]} name="presence-{key}" value={"NP"}>Absent</RadioItem>
-                    <RadioItem bind:group={$delegateAttendance[key]} name="presence-{key}" value={"P"}>Present</RadioItem>
-                    <RadioItem bind:group={$delegateAttendance[key]} name="presence-{key}" value={"PV"}>Present and Voting</RadioItem>
+                    {#each Object.entries(radio) as [value, { label, icon }]}
+                        <RadioItem bind:group={$delegateAttendance[key]} name="presence-{key}" {value}>
+                            <!-- If on a small device, use an icon -->
+                            <div class="flex justify-center items-center md:hidden" aria-label={label} title={label}>
+                                <Icon {icon} width="24" height="24" />
+                            </div>
+                            <!-- If on a larger device, use the full text -->
+                            <span class="hidden md:block">{label}</span>
+                        </RadioItem>
+                    {/each}
                 </RadioGroup>
             </div>
         </div>

--- a/src/routes/dashboard/speaker-list/+page.svelte
+++ b/src/routes/dashboard/speaker-list/+page.svelte
@@ -6,6 +6,7 @@
     import { getSessionDataContext } from "$lib/stores/session";
     import { getStatsContext, updateStats } from "$lib/stores/stats";
     import { parseTime } from "$lib/util/time";
+    import Icon from "@iconify/svelte";
     import { untrack } from "svelte";
 
     const { settings: { delegateAttributes }, presentDelegates, speakersList: order } = getSessionDataContext();
@@ -45,34 +46,47 @@
     }
 </script>
 
-<div class="grid grid-cols-[2fr_1fr] gap-12 h-full">
-    <!-- Left -->
-    <div class="flex flex-col gap-5 self-center">
-        {#if typeof selectedSpeaker !== "undefined"}
-            <DelLabel key={selectedSpeaker.key} attrs={$delegateAttributes[selectedSpeaker.key]} />
-        {/if}
-        
-        <Timer
-            name="total"
-            bind:duration
-            bind:running
-            bind:this={timer}
-            disableKeyHandlers={typeof selectedSpeaker === "undefined"}
-            onPause={(t) => updateStats(stats, selectedSpeaker?.key, dat => dat.durationSpoken += t)}
-            editable
-        />
-        <div class="flex flex-row gap-3 justify-center">
-            {#if !running}
-                <button class="btn variant-filled-primary" disabled={typeof selectedSpeaker === "undefined"} onclick={() => running = true}>Start</button>
-            {:else}
-                <button class="btn variant-filled-primary" onclick={() => running = false}>Pause</button>
+<div class="flex flex-col lg:flex-row h-full gap-8 items-stretch">
+    <!--
+        Under mobile, the timer encompasses the whole page 
+        and the speakers list can be accessed by scrolling down.
+
+        Under desktop, both are on the same screen,
+        with the left side being the timer and the right side being the speakers list.
+    -->
+    <!-- Left/Top -->
+    <div class="flex flex-col flex-grow flex-shrink-0 basis-full lg:basis-auto">
+        <div class="flex flex-col gap-5 justify-center flex-grow">
+            {#if typeof selectedSpeaker !== "undefined"}
+                <DelLabel key={selectedSpeaker.key} attrs={$delegateAttributes[selectedSpeaker.key]} />
             {/if}
-            <button class="btn variant-filled-primary" disabled={speakersList?.isAllDone() ?? true} onclick={next}>Next</button>
-            <button class="btn variant-filled-primary" disabled={!timer?.canReset()} onclick={reset}>Reset</button>
+            
+            <Timer
+                name="total"
+                bind:duration
+                bind:running
+                bind:this={timer}
+                disableKeyHandlers={typeof selectedSpeaker === "undefined"}
+                onPause={(t) => updateStats(stats, selectedSpeaker?.key, dat => dat.durationSpoken += t)}
+                editable
+            />
+            <div class="flex flex-row gap-3 justify-center">
+                {#if !running}
+                    <button class="btn variant-filled-primary" disabled={typeof selectedSpeaker === "undefined"} onclick={() => running = true}>Start</button>
+                {:else}
+                    <button class="btn variant-filled-primary" onclick={() => running = false}>Pause</button>
+                {/if}
+                <button class="btn variant-filled-primary" disabled={speakersList?.isAllDone() ?? true} onclick={next}>Next</button>
+                <button class="btn variant-filled-primary" disabled={!timer?.canReset()} onclick={reset}>Reset</button>
+            </div>
+        </div>
+        <!-- Mobile chevron -->
+        <div class="flex justify-center lg:hidden">
+            <Icon icon="mdi:chevron-down" width="24" height="24" />
         </div>
     </div>
-    <!-- Right -->
-    <div class="flex flex-col gap-4 h-full overflow-hidden">
+    <!-- Right/Bottom -->
+    <div class="flex flex-col gap-4 h-full lg:overflow-hidden lg:max-w-[33%]">
         <!-- List -->
         <SpeakerList
             bind:order={$order}

--- a/src/routes/dashboard/speaker-list/+page.svelte
+++ b/src/routes/dashboard/speaker-list/+page.svelte
@@ -6,7 +6,7 @@
     import { getSessionDataContext } from "$lib/stores/session";
     import { getStatsContext, updateStats } from "$lib/stores/stats";
     import { parseTime } from "$lib/util/time";
-    import { tick, untrack } from "svelte";
+    import { untrack } from "svelte";
 
     const { settings: { delegateAttributes }, presentDelegates, speakersList: order } = getSessionDataContext();
     const { stats } = getStatsContext();
@@ -26,13 +26,11 @@
             speakersList?.start();
         })
     });
-    async function reset() {
+    function reset() {
         timer?.reset();
-        await tick();
     }
     // Button triggers
-    async function next() {
-        await reset();
+    function next() {
         speakersList?.next();
     }
     function setDuration(e: SubmitEvent) {


### PR DESCRIPTION
Makes miscellaneous UI changes that generally improve CouchMUN's appearance on mobile devices and increases visibility of certain features
- **Mobile (resolves #19)**: 
    - Rescales UI in Roll Call, Speaker List (& related pages), and Points & Motions
    - Replaces certain text on smaller screens with semantic icons
- **Speakers List**:
    - Revises Add/Clear UI
- Modifies P&M sort button to better fit the UI and to react to sortability
- Adds hover/focus indicator for `contenteditable` elements

