### PR TITLE
sorting rr patch - fatal bug

### DIFF
--- a/src/lib/components/MotionForm.svelte
+++ b/src/lib/components/MotionForm.svelte
@@ -37,6 +37,10 @@
     function submitMotion(e: SubmitEvent) {
         e.preventDefault();
 
+        if (inputMotion.kind === "rr") {
+            inputMotion.totalSpeakers = $presentDelegates.length.toString();
+        }
+
         // Filter out any keys that aren't the correct kind:
         for (let key of Object.keys(inputMotion)) {
             if (!hasField(inputMotion, [key])) {

--- a/src/lib/motions/definitions.ts
+++ b/src/lib/motions/definitions.ts
@@ -19,7 +19,7 @@ export const MOTION_LABELS: Record<MotionKind, string> = {
 export const MOTION_FIELDS = {
     mod:   ["id", "delegate", "kind", "totalTime", "speakingTime", "topic", "isExtension"],
     unmod: ["id", "delegate", "kind", "totalTime", "isExtension"],
-    rr:    ["id", "delegate", "kind", "speakingTime", "topic"],
+    rr:    ["id", "delegate", "kind", "totalSpeakers", "speakingTime", "topic"],
     other: ["id", "delegate", "kind", "totalTime", "topic"]
 } as const;
 
@@ -75,7 +75,8 @@ export function createMotionSchema(delegates: Record<string, DelegateAttrs>, pre
         }),
         base("rr").extend({
             speakingTime: timeSchema("Speaking time"),
-            topic: topicSchema()
+            topic: topicSchema(),
+            totalSpeakers: z.string().transform((s) => parseInt(s))
         }),
         base("other").extend({
             totalTime: timeSchema("Total time"),

--- a/src/lib/motions/sort.ts
+++ b/src/lib/motions/sort.ts
@@ -44,12 +44,14 @@ function getSortProperty(m: Motion, key: SortOrderProperty): unknown {
     if (key === "delegate") {
         if (hasSortProperty(m, key)) return m.delegate;
     } else if (key === "nSpeakers") {
+        if (m.kind === "rr") return m.totalSpeakers;
         if (hasSortProperty(m, key)) return m.totalTime / m.speakingTime;
     } else if (key === "speakingTime") {
         if (hasSortProperty(m, key)) return m.speakingTime;
     } else if (key === "topic") {
         if (hasSortProperty(m, key)) return m.topic;
     } else if (key === "totalTime") {
+        if (m.kind === "rr") return m.totalSpeakers * m.speakingTime;
         if (hasSortProperty(m, key)) return m.totalTime;
     } else {
         key satisfies never;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -166,6 +166,7 @@ export type Motion = {
     kind: "rr",
     speakingTime: number,
     topic: string
+    totalSpeakers: number
 } | {
     id: string,
     delegate: string,

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -96,9 +96,14 @@
     $motions = $motions.sort(motionComparator($sortOrder));
   }
   // Check every window of two motions is in the right order:
-  const motionsSorted = derived(motions, $m => 
-    $m.slice(0, -1).every((motion, i) => motionComparator($sortOrder)(motion, $m[i + 1]) <= 0)
-  );
+  const motionsSorted = derived(motions, $m => {
+    try {
+      return $m.slice(0, -1).every((motion, i) => motionComparator($sortOrder)(motion, $m[i + 1]) <= 0);
+    } catch {
+      // If comparing crashes, don't allow the button to do anything
+      return true;
+    }
+  });
 </script>
 
 <div class="grid gap-5 min-h-full md:grid-cols-[1fr_2fr] md:h-full">

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -190,9 +190,9 @@
               <td>{motionName(motion)}</td>
               <td><DelLabel key={motion.delegate} attrs={$delegateAttributes[motion.delegate]} inline /></td>
               <td>{apply(motion, ["topic"], m => m.topic, "-")}</td>
-              <td>{apply(motion, ["totalTime"], m => stringifyTime(m.totalTime), "-")}</td>
+              <td>{'totalSpeakers' in motion ? stringifyTime(motion.totalSpeakers * motion.speakingTime) : apply(motion, ["totalTime"], m => stringifyTime(m.totalTime), "-")}</td>
               <td>{apply(motion, ["speakingTime"], m => stringifyTime(m.speakingTime), "-")}</td>
-              <td>{apply(motion, ["totalTime", "speakingTime"], m => numSpeakersStr(m.totalTime, m.speakingTime), "-")}</td>
+              <td>{'totalSpeakers' in motion ? motion.totalSpeakers : apply(motion, ["totalTime", "speakingTime"], m => numSpeakersStr(m.totalTime, m.speakingTime), "-")}</td>
             </tr>
           {/each}
         </tbody>


### PR DESCRIPTION
addresses #29 

patches current fatal bug with nSpeakers and totalTime sort with round robins. 

replicate on prev:
1. create round robin
2. create mod
3. create another mod (forces sort which crashes)

nSpeakers sort requires totalTime and speakingTime (totalTime / speakingTime) of which rr does not have. 
totalTime sort requires totalTime of which rr does not have

added totalPresent to track total speakers and override totalTime and speakingTime for nSpeakers, also derives into totalTime by multiplying by speakingTime.