### PR TITLE
Remove enforced round-robin order

### DIFF
--- a/src/lib/components/SpeakerList.svelte
+++ b/src/lib/components/SpeakerList.svelte
@@ -7,20 +7,17 @@
  -->
 <script lang="ts">
     import { DragDropProvider } from "@dnd-kit/svelte";
-    import { Dialog } from "@skeletonlabs/skeleton-svelte";
     import { tick, untrack, type Snippet } from "svelte";
     import { flip } from "svelte/animate";
 
-    import DelCombobox from "$lib/components/controls/DelCombobox.svelte";
     import DelLabel from "$lib/components/del-label/DelLabel.svelte";
-    import ConfirmModal from "$lib/components/modals/ConfirmModal.svelte";
+    import SpeakerListEditControls from "$lib/components/SpeakerListEditControls.svelte";
     import { type Delegate, findDelegate } from "$lib/db/delegates";
     import type { DelegateID, Speaker, SpeakerEntryID } from "$lib/types";
     import { a11yLabel } from "$lib/util";
     import { createSortable, handleDrag } from "$lib/util/dnd";
     import { proxify } from "$lib/util/sv.svelte";
     import MdiCancel from "~icons/mdi/cancel";
-    import MdiDelete from "~icons/mdi/delete";
     import MdiDragVertical from "~icons/mdi/drag-vertical";
     
     interface Props {
@@ -40,13 +37,6 @@
          * provided by this component.
          */
         controls?: Snippet;
-        /**
-         * Controls placed above the add speakers control.
-         * 
-         * If `controls` is defined, neither this nor the default add speakers control
-         * will appear.
-         */
-        subcontrols?: Snippet;
         /**
          * The title of the component, which appears at the top. 
          * 
@@ -74,7 +64,6 @@
         order = $bindable([]),
         delegates = [],
         controls = undefined,
-        subcontrols = undefined,
         title = "Speakers List",
         extra,
         onBeforeSpeakerUpdate = undefined,
@@ -117,9 +106,6 @@
         });
     }
 
-    let openModals = $state({
-        clearSpeakers: false
-    });
 
     /**
      * Whether the speakers list is complete (there are no other speakers left in the list).
@@ -362,36 +348,6 @@
     {#if controls}
         {@render controls()}
     {:else}
-        <div class="flex flex-col items-stretch gap-1">
-            {@render subcontrols?.()}
-            <div class="flex flex-row gap-1 items-center">
-                <!-- Delegate combobox -->
-                <DelCombobox
-                    {delegates}
-                    selectionBehavior="clear"
-                    class="grow"
-                    forgetSelected
-                    onSelect={addSpeaker}
-                />
-                <!-- Clear order -->
-                <ConfirmModal
-                    bind:open={openModals.clearSpeakers}
-                    success={() => order = []}
-                >
-                    {#snippet trigger()}
-                        <Dialog.Trigger
-                            class="btn-icon-std preset-filled-primary-500"
-                            disabled={order.length === 0}
-                            {...a11yLabel("Clear Speakers List")}
-                        >
-                            <MdiDelete />
-                        </Dialog.Trigger>
-                    {/snippet}
-                    {#snippet content()}
-                        Are you sure you want to clear the Speakers List?
-                    {/snippet}
-                </ConfirmModal>
-            </div>
-        </div>
+        <SpeakerListEditControls {delegates} {order} onSelect={addSpeaker} />
     {/if}
 </div>

--- a/src/lib/components/SpeakerListEditControls.svelte
+++ b/src/lib/components/SpeakerListEditControls.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+    import { Dialog } from "@skeletonlabs/skeleton-svelte";
+
+    import DelCombobox from "$lib/components/controls/DelCombobox.svelte";
+    import ConfirmModal from "$lib/components/modals/ConfirmModal.svelte";
+    import { Delegate } from "$lib/db/delegates";
+    import type { DelegateID, Speaker } from "$lib/types";
+    import { a11yLabel } from "$lib/util";
+    import MdiDelete from "~icons/mdi/delete";
+
+    interface Props {
+        delegates: Delegate[],
+        order: Speaker[],
+        /**
+         * When a delegate is selected in the combobox,
+         * this callback is called.
+         */
+        onSelect?(key: DelegateID): void;
+    }
+
+    let { delegates, order, onSelect }: Props = $props();
+    let openClearSpeakers = $state(false);
+</script>
+<div class="flex flex-row gap-1 items-center">
+    <!-- Delegate combobox -->
+    <DelCombobox
+        delegates={delegates}
+        selectionBehavior="clear"
+        class="grow"
+        forgetSelected
+        {onSelect}
+    />
+    <!-- Clear order -->
+    <ConfirmModal
+        bind:open={openClearSpeakers}
+        success={() => order = []}
+    >
+        {#snippet trigger()}
+            <Dialog.Trigger
+                class="btn-icon-std preset-filled-primary-500"
+                disabled={order.length === 0}
+                {...a11yLabel("Clear Speakers List")}
+            >
+                <MdiDelete />
+            </Dialog.Trigger>
+        {/snippet}
+        {#snippet content()}
+            Are you sure you want to clear the Speakers List?
+        {/snippet}
+    </ConfirmModal>
+</div>

--- a/src/lib/components/SpeakerListFirstLast.svelte
+++ b/src/lib/components/SpeakerListFirstLast.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import DelLabel from "$lib/components/del-label/DelLabel.svelte";
+    import SpeakerList from "$lib/components/SpeakerList.svelte";
+    import { findDelegate, type Delegate } from "$lib/db/delegates";
+    import type { DelegateID, Speaker } from "$lib/types";
+    import { lazyslide } from "$lib/util";
+
+    interface Props {
+        delegates: Delegate[];
+        order: Speaker[];
+        proposer: DelegateID;
+        speakersList: SpeakerList | undefined;
+    }
+    let { delegates, order, proposer, speakersList }: Props = $props();
+</script>
+
+{#if !order.some((s) => s.key == proposer)}
+    <div
+        class="card card-filled p-2 flex justify-between items-center preset-filled-surface-200-800"
+        transition:lazyslide
+    >
+        <DelLabel attrs={findDelegate(delegates, proposer)} inline />
+        <div>
+            <button
+                class="btn preset-filled-primary-500"
+                onclick={() => speakersList?.addSpeakerFirst(proposer)}
+            >
+                First
+            </button>
+            <button
+                class="btn preset-filled-primary-500"
+                onclick={() => speakersList?.addSpeakerLast(proposer)}
+            >
+                Last
+            </button>
+        </div>
+    </div>
+{/if}

--- a/src/lib/components/motions/page/ModCaucus.svelte
+++ b/src/lib/components/motions/page/ModCaucus.svelte
@@ -5,16 +5,15 @@
     - An editable speakers list
 -->
 <script lang="ts">
-    import DelLabel from "$lib/components/del-label/DelLabel.svelte";
     import { numSpeakersStr } from "$lib/components/motions/form/MotionForm.svelte";
     import TimerPanel from "$lib/components/motions/TimerPanel.svelte";
     import SpeakerList from "$lib/components/SpeakerList.svelte";
+    import SpeakerListEditControls from "$lib/components/SpeakerListEditControls.svelte";
+    import SpeakerListFirstLast from "$lib/components/SpeakerListFirstLast.svelte";
     import type Timer from "$lib/components/Timer.svelte";
     import { getSessionContext } from "$lib/context/index.svelte";
-    import { findDelegate } from "$lib/db/delegates";
     import { db } from "$lib/db/index.svelte";
     import type { Motion, Speaker } from "$lib/types";
-    import { lazyslide } from "$lib/util";
 
     interface Props {
         motion: Motion & { kind: "mod" };
@@ -88,19 +87,11 @@
             {#snippet title()}
                 Speakers List (<span class="tabular-nums">{order.length}/{numSpeakersStr(motion.totalTime, motion.speakingTime)}</span>)
             {/snippet}
-            {#snippet subcontrols()}
-                {#if !order.some(s => s.key == motion.delegate)}
-                    <div
-                        class="card card-filled p-2 flex justify-between items-center preset-filled-surface-200-800"
-                        transition:lazyslide
-                    >
-                        <DelLabel attrs={findDelegate($delegates, motion.delegate)} inline />
-                        <div>
-                            <button class="btn preset-filled-primary-500" onclick={() => speakersList?.addSpeakerFirst(motion.delegate)}>First</button>
-                            <button class="btn preset-filled-primary-500" onclick={() => speakersList?.addSpeakerLast(motion.delegate)}>Last</button>
-                        </div>
-                    </div>
-                {/if}
+            {#snippet controls()}
+                <div class="flex flex-col items-stretch gap-1">
+                    <SpeakerListFirstLast delegates={$delegates} {order} proposer={motion.delegate} {speakersList} />
+                    <SpeakerListEditControls delegates={$delegates} {order} onSelect={speakersList?.addSpeaker} />
+                </div>
             {/snippet}
         </SpeakerList>
     </div>

--- a/src/lib/components/motions/page/RoundRobin.svelte
+++ b/src/lib/components/motions/page/RoundRobin.svelte
@@ -7,10 +7,12 @@
 <script lang="ts">
     import TimerPanel from "$lib/components/motions/TimerPanel.svelte";
     import SpeakerList from "$lib/components/SpeakerList.svelte";
+    import SpeakerListEditControls from "$lib/components/SpeakerListEditControls.svelte";
+    import SpeakerListFirstLast from "$lib/components/SpeakerListFirstLast.svelte";
     import { getSessionContext } from "$lib/context/index.svelte";
     import { db } from "$lib/db/index.svelte";
     import type { Motion, Speaker } from "$lib/types";
-
+    
     interface Props {
         motion: Motion & { kind: "rr" };
         order: Speaker[]
@@ -22,7 +24,11 @@
     
     let timerPanel = $state<TimerPanel>();
     let speakersList = $state<SpeakerList>();
-    
+    const comboboxDelegates = $derived.by(() => {
+        let addedDelegates = new Set(order.map(s => s.key));
+        return $delegates.filter(d => !addedDelegates.has(d.id));
+    });
+
     function reset() {
         timerPanel?.reset();
     }
@@ -62,7 +68,12 @@
             onBeforeSpeakerUpdate={reset}
             onMarkComplete={(key, isRepeat) => { if (!isRepeat) db.updateDelegate(key, d => { d.stats.timesSpoken++; }) }}
         >
-            {#snippet controls()}{/snippet}
+            {#snippet controls()}
+                <div class="flex flex-col items-stretch gap-1">
+                    <SpeakerListFirstLast delegates={$delegates} {order} proposer={motion.delegate} {speakersList} />
+                    <SpeakerListEditControls delegates={comboboxDelegates} {order} onSelect={speakersList?.addSpeaker} />
+                </div>
+            {/snippet}
         </SpeakerList>
     </div>
 </div>

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -101,11 +101,7 @@
   async function acceptMotion(motion: Motion) {
     // Update selected motion and initialize selected motion state:
     $selectedMotion = motion;
-    if (motion.kind === "rr") {
-      $selectedMotionState = { speakersList: $delegates.filter(d => d.isPresent()).map(s => createSpeaker(s.id)) };
-    } else {
-      $selectedMotionState = { speakersList: [] };
-    }
+    $selectedMotionState = { speakersList: [] };
 
     $motions = [];
     await db.updateDelegate(motion.delegate, d => { d.stats.motionsAccepted++; });


### PR DESCRIPTION
Removes enforced round-robin order, instead following a style similar to moderated caucuses.
The combobox is now instead restricted to prevent duplicate entries from being added.

This also slightly refactors the SpeakerList component to simplify props and reduce redundancy.
