### PR TITLE
Various UI tweaks to improve usability and accessibility

### DIFF
--- a/src/lib/components/controls/DelCombobox.svelte
+++ b/src/lib/components/controls/DelCombobox.svelte
@@ -140,7 +140,7 @@
         <Combobox.Trigger />
     </Combobox.Control>
     <Portal>
-        <Combobox.Positioner class="z-1! max-h-96 overflow-auto">
+        <Combobox.Positioner class="z-51! max-h-96 overflow-auto">
             <Combobox.Content>
                 {#each collection.group() as [type, items] (type)}
                     <Combobox.ItemGroup>

--- a/src/lib/components/del-label/DelFlag.svelte
+++ b/src/lib/components/del-label/DelFlag.svelte
@@ -79,21 +79,18 @@
 {#if _flagURL}
     <img
         src={_flagURL}
-        alt="Flag of {label}"
+        alt=""
         class={height}
     >
 {:else if fallback === "un"}
     <img
         src={getFlagUrl("un", false)!.toString()}
-        alt="Flag of {label} (missing)"
+        alt=""
         class={height}
     >
 {:else if fallback === "icon"}
     <!-- HACK: Just don't use this if not inline. -->
-    <MdiFlagOff 
-        role="img" 
-        aria-label="Flag of {label} (missing)"
-    />
+    <MdiFlagOff role="none" />
 {:else}
     <!-- do nothing -->
 {/if}

--- a/src/lib/components/motions/form/MotionForm.svelte
+++ b/src/lib/components/motions/form/MotionForm.svelte
@@ -124,6 +124,8 @@
             inputError = undefined;
 
             submit?.(result.data);
+            // Refocus to top of form:
+            (formEl?.children[0] as HTMLElement)?.focus();
         } else {
             inputError = formatValidationError(result.error);
         }

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -240,7 +240,11 @@
                     >
                       <MdiCheck class="text-success-700" />
                     </button>
-                    <button class="btn-icon-std p-1" onclick={() => openModals.editMotion = i}>
+                    <button
+                      class="btn-icon-std p-1"
+                      onclick={() => openModals.editMotion = i}
+                      {...a11yLabel(`Edit ${delName}'s Motion`)}
+                    >
                       <MdiPencil />
                     </button>
                   </div>

--- a/src/routes/dashboard/points-motions/+page.svelte
+++ b/src/routes/dashboard/points-motions/+page.svelte
@@ -214,6 +214,7 @@
                   "data-dnd-dragging:preset-tonal-primary"
                 ]}
                 animate:flip={{ duration: 150 }}
+                ondblclick={() => openModals.editMotion = i}
                 {...a11yLabel(`${delName}'s Motion`)}
               >
                 <td>{motionName(motion)}</td>


### PR DESCRIPTION
Accessibility changes:

- Adds missing accessibility labels on the edit button for each motion
- Remove alt text for delegate flags (which are mostly decorative, are always paired with a label, and caused double-speaking on screen-readers)

Usability changes:

- Adds refocus to the top of the motion form on motion submit (to allow faster motion additions)
- Adds double-click to edit on motion rows
- Properly shows the delegate combobox in the edit motion modal
